### PR TITLE
exclude self healing/barrier

### DIFF
--- a/src/main/java/org/vmy/ParseBot.java
+++ b/src/main/java/org/vmy/ParseBot.java
@@ -254,10 +254,12 @@ public class ParseBot {
                     if(!ehObject.isNull("outgoingHealingAllies")) {
                         JSONArray ohArray = ehObject.getJSONArray("outgoingHealingAllies");
                         for (int q=0; q<ohArray.length(); q++) {
-                            JSONArray ihArray = ohArray.getJSONArray(q);
-                            JSONObject healObj = (JSONObject) ihArray.get(0);
-                            healing += healObj.getInt("healing");
-                            downedHealing += healObj.getInt("downedHealing");
+                            if (i != q) { // exclude this player healing themself
+                                JSONArray ihArray = ohArray.getJSONArray(q);
+                                JSONObject healObj = (JSONObject) ihArray.get(0);
+                                healing += healObj.getInt("healing");
+                                downedHealing += healObj.getInt("downedHealing");
+                            }
                         }
                     }
 //                    if(!ehObject.isNull("alliedHealingDist")) {
@@ -280,9 +282,11 @@ public class ParseBot {
                     if(!ehObject.isNull("outgoingBarrierAllies")) {
                         JSONArray ohArray = ehObject.getJSONArray("outgoingBarrierAllies");
                         for (int q=0; q<ohArray.length(); q++) {
-                            JSONArray ihArray = ohArray.getJSONArray(q);
-                            JSONObject healObj = (JSONObject) ihArray.get(0);
-                            barrier += healObj.getInt("barrier");
+                            if (i != q) { // exclude this player applying barrier to themself
+                                JSONArray ihArray = ohArray.getJSONArray(q);
+                                JSONObject healObj = (JSONObject) ihArray.get(0);
+                                barrier += healObj.getInt("barrier");
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Cleanses don't include CondiCleanseSelf, so this PR skips adding healing and barrier with the same source and destination player.

The main players list should be in the same order the outgoingHealingAllies/outgoingBarrierAllies arrays, so this PR just adds an if statement that skips adding healing/barrier if the player index matches healing/barrier index.